### PR TITLE
be less strict with version requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
 
     license='MIT', #TODO
 
-    python_requires='>=3.6',
+    python_requires='>=3',
 
     packages=find_packages(exclude=["test_*", "TODO*"]),
 

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
 
     license='MIT', #TODO
 
-    python_requires='>=3',
+    python_requires='>=3.4',
 
     packages=find_packages(exclude=["test_*", "TODO*"]),
 


### PR DESCRIPTION
I am proposing this pull request as I wish to use this package with python3.4.
The package appears to work well with python3.4 as-is but due to the current version requirement it can't be installed from pypi.