### PR TITLE
fix: pin colored version to <1.5.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ keywords = [
 ]
 
 dependencies = [
-    "colored",
+    "colored<1.5.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
Hi @petercorke! This PR fixes #4.

Colored maintainer released a 1.5.0 version that introduced breaking API changes, renaming functions `fg` and `attr` to `fore` and `style` respectively. Since this didn't follow semantic versioning, colored's maintainer [deleted the 1.5.0 version](https://gitlab.com/dslackw/colored/-/issues/27#tasks) and will re-release a 2.0.0 version instead. Colored's version should still be pinned to avoid breaking changes in the future.