### PR TITLE
Fix bug with "TypeError: fore|back|style() takes no arguments

### DIFF
--- a/ansitable/table.py
+++ b/ansitable/table.py
@@ -1376,19 +1376,19 @@ class ANSITable:
 
     def _FG(self, c):
         if _unicode and self.color and c is not None:
-            return fore(c)
+            return fg(c)
         else:
             return ""
 
     def _BG(self, c):
         if _unicode and self.color and c is not None:
-            return back(c)
+            return bg(c)
         else:
             return ""
 
     def _ATTR(self, c):
         if _unicode and self.color and c is not None:
-            return style(c)
+            return attr(c)
         else:
             return ""
 


### PR DESCRIPTION
Dear Mr. Corke,

I hope this letter finds you well.

I wanted to inform you that I am currently using a system with Docker-ubuntu20.04 and Python 3.8.5. I am incredibly grateful for your open-source project, roboticstoolbox-python, which I have been diligently studying.

Furthermore, I recently encountered an issue and debugged the fore|back|style errors. I discovered that for known and definite rendering effects, such as text, one can set the color in the form of fore.GREEN. However, for unknown and dynamic content, it is necessary to use fg(set). If this modification is not made, an error occurs when printing (robot). So far, I have not encountered any other anomalies.

If you have any questions or concerns regarding this matter, please do not hesitate to reach out to me via email at [Arinffy@outlook.com](mailto:Arinffy@outlook.com).

Thank you once again for your valuable contributions to the open-source community.

Yours sincerely,

Arinffy