### PR TITLE
ci: add Python 3.14 to supported versions and CI matrix

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
     - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",


### PR DESCRIPTION
Adds Python 3.14 to pyproject.toml classifiers and the CI test matrix.