### PR TITLE
docs: migrate from sphinx-autorun to sphinx-pyrunblock

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -58,7 +58,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install .[docs]
-        pip install git+https://github.com/petercorke/sphinx-autorun.git
     - name: Build docs
       run: |
         cd docs

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -47,14 +47,14 @@ extensions = [
     "sphinx.ext.napoleon",
     "sphinx_autodoc_typehints",
     "sphinx_favicon",
-    "sphinx_autorun",
+    "sphinx_pyrunblock",
     "sphinx_copybutton",
 ]
 
 autosummary_generate = True
 autodoc_member_order = "bysource"
 
-# sphinx-autorun configuration
+# sphinx-pyrunblock configuration
 autorun_languages = {
     "pycon": "python3",
     "pycon_prefix_chars": 4,

--- a/docs/source/intro.rst
+++ b/docs/source/intro.rst
@@ -10,6 +10,7 @@ Starting simple
 ~~~~~~~~~~~~~~~
 
 .. runblock:: plain_python
+    :no-prompt:
 
     from ansitable import ANSITable
 
@@ -33,6 +34,7 @@ Borders
 You can add borders made up of regular ASCII characters:
 
 .. runblock:: plain_python
+    :no-prompt:
 
     from ansitable import ANSITable, Column
     table = ANSITable(
@@ -49,6 +51,7 @@ You can add borders made up of regular ASCII characters:
 Or use ANSI box-drawing characters (supported by most terminal emulators):
 
 .. runblock:: plain_python
+    :no-prompt:
 
     from ansitable import ANSITable, Column
     table = ANSITable(
@@ -70,6 +73,7 @@ Formatting and alignment
 Specify Python format strings for columns:
 
 .. runblock:: plain_python
+    :no-prompt:
 
     from ansitable import ANSITable, Column
     table = ANSITable(
@@ -88,6 +92,7 @@ Control alignment with ``colalign`` (data) and ``headalign`` (heading):
 - ``"^"`` — center
 
 .. runblock:: plain_python
+    :no-prompt:
 
     from ansitable import ANSITable, Column
     table = ANSITable(
@@ -104,6 +109,7 @@ Control alignment with ``colalign`` (data) and ``headalign`` (heading):
 Add dividing lines with ``.rule()``:
 
 .. runblock:: plain_python
+    :no-prompt:
 
     from ansitable import ANSITable, Column
     table = ANSITable(
@@ -124,6 +130,7 @@ Width constraints
 Limit column width with the ``width`` argument:
 
 .. runblock:: plain_python
+    :no-prompt:
 
     from ansitable import ANSITable, Column
     table = ANSITable(
@@ -190,6 +197,7 @@ Sorting
 Sort table rows by a column:
 
 .. runblock:: plain_python
+    :no-prompt:
 
     from ansitable import ANSITable
     table = ANSITable("name", "score")
@@ -215,6 +223,7 @@ Export tables to markup languages for use in documents:
 **Markdown:**
 
 .. runblock:: plain_python
+    :no-prompt:
 
     from ansitable import ANSITable
     table = ANSITable("col1", "column 2 has a big header", "column 3")
@@ -228,6 +237,7 @@ Export tables to markup languages for use in documents:
 Supports CSS styling of cells and colors.
 
 .. runblock:: plain_python
+    :no-prompt:
 
     from ansitable import ANSITable
     table = ANSITable("col1", "column 2 has a big header", "column 3")
@@ -239,6 +249,7 @@ Supports CSS styling of cells and colors.
 **reStructuredText (ReST) "simple table":**
 
 .. runblock:: plain_python
+    :no-prompt:
 
     from ansitable import ANSITable
     table = ANSITable("col1", "column 2 has a big header", "column 3")
@@ -252,6 +263,7 @@ Supports CSS styling of cells and colors.
 Alignment options supported.
 
 .. runblock:: plain_python
+    :no-prompt:
 
     from ansitable import ANSITable
     table = ANSITable("col1", "column 2 has a big header", "column 3")
@@ -263,6 +275,7 @@ Alignment options supported.
 **Wikitable (Wikipedia):**
 
 .. runblock:: plain_python
+    :no-prompt:
 
     from ansitable import ANSITable
     table = ANSITable("col1", "column 2 has a big header", "column 3")
@@ -274,6 +287,7 @@ Alignment options supported.
 **CSV:**
 
 .. runblock:: plain_python
+    :no-prompt:
 
     from ansitable import ANSITable
     table = ANSITable("col1", "column 2 has a big header", "column 3")
@@ -288,6 +302,7 @@ Matrices
 Display NumPy arrays as formatted matrices:
 
 .. runblock:: plain_python
+    :no-prompt:
 
     from ansitable import ANSIMatrix
     import numpy as np
@@ -300,6 +315,7 @@ Display NumPy arrays as formatted matrices:
 Add superscript and subscript suffixes:
 
 .. runblock:: plain_python
+    :no-prompt:
 
     from ansitable import ANSIMatrix
     import numpy as np
@@ -315,6 +331,7 @@ Pandas integration
 Convert Pandas DataFrames to ANSITable:
 
 .. runblock:: plain_python
+    :no-prompt:
 
     import pandas as pd
     from ansitable import ANSITable
@@ -326,6 +343,7 @@ Convert Pandas DataFrames to ANSITable:
 Convert ANSITable back to DataFrame:
 
 .. runblock:: plain_python
+    :no-prompt:
 
     from ansitable import ANSITable
     import pandas as pd

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ dependencies = ["colored"]
 docs = [
     "sphinx",
     "sphinx-rtd-theme",
-    "sphinx-autorun",
+    "sphinx-pyrunblock",
     "sphinx-copybutton",
     "sphinxcontrib-jsmath",
     "sphinx-markdown-tables",


### PR DESCRIPTION
## Root cause of the failing CI docs-build job

The upstream `sphinx-autorun` package (PyPI, imported as `sphinx_autorun`) hardcodes `output_encoding="ascii"` for the subprocess output of each `runblock` example, with no error handling. Any example whose output contains a non-ASCII byte — e.g. ansitable's own box-drawing table borders — crashes the docs build with an uncaught `UnicodeDecodeError`.

## Fix

Switch to `sphinx-pyrunblock`, Peter's actively maintained fork, which captures output via `io.StringIO` (pure `str`, no byte decoding) and is immune to this class of bug.

- `pyproject.toml` / `conf.py`: swap the `docs` extra and extension name.
- `docs/source/intro.rst`: add `:no-prompt:` to every `.. runblock:: plain_python` block, to preserve the original raw/no-prompt rendering. As a side effect, this also fixes 18 pre-existing "unknown Pygments lexer 'plain_python'" warnings, since these blocks now correctly render with the `python` lexer.
- `.github/workflows/master.yml`: remove the now-pointless `pip install git+.../sphinx-autorun.git` step — that GitHub repo was renamed to sphinx-pyrunblock, so the line was silently installing an already-covered, differently-named package `conf.py` never imported.

Verified locally: docs build succeeds and the box-drawing example (the case that used to crash) renders correctly.